### PR TITLE
Corrected parsing negative temps, added Fahrenheit functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.js
+++ b/index.js
@@ -18,20 +18,24 @@ exports.getDevices=function() {
 
 exports.readTemperature=function(path, callback, converter){
  if(!converter) {
-  converter=exports.toDegreeCelcius;
+  converter=exports.toDegreeCelsius;
  }
  var device = new HID.HID(path);
  device.write(readCommand);
  device.read(function(err,response){
+   device.close();
    if(err) {
     callback.call(this,err,null); 
    } else {
-    callback.call(this,null, converter(response[2],response[3]));
+    callback.call(this,null, converter(response[2],response[3]), converter(response[4], response[5]));
    }
  });
 }
 
 exports.toDegreeCelsius = function(hiByte, loByte) {
+    if (hiByte == 255 && loByte == 255) {
+        return NaN;
+    }
     if ((hiByte & 128) == 128) {
         return -((256-hiByte) + (1 + ~(loByte >> 4)) / 16.0);
     }
@@ -39,12 +43,12 @@ exports.toDegreeCelsius = function(hiByte, loByte) {
 }
 
 // 'Celsius' is misspelled, but left here so as not to break existing code
-exports.toDegreeCelcius = function(hiByte, loByte) {
-    return exports.toDegreeCelsius(hiByte, loByte);
+exports.toDegreeCelcius = function(hibyte, lobyte) {
+    return exports.toDegreeCelsius(hibyte, lobyte);
 }
 
 exports.toDegreeFahrenheit = function(hiByte, loByte) {
-    return exports.celsiusToFahrenheit(exports.toDegreeCelcius(hiByte, loByte));
+    return exports.celsiusToFahrenheit(exports.toDegreeCelsius(hiByte, loByte));
 }
 
 exports.celsiusToFahrenheit = function(c) {

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
   "engines": {
     "node": "*"
   },
-  "dependencies": {"node-hid":"~0.2.2"}
+  "dependencies": {"node-hid":"~0.5.1"}
 }

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,16 @@ var devices=thermometers.getDevices();
 
 console.log("Devices found:"+devices[0]);
 
-thermometers.readTemperature(devices[0], function(err, value) {
-  console.log("Result:"+value);
+devices.forEach(function(device) {
+    console.log(device);
+
+    thermometers.readTemperature(device, function(err, intTemp, extTemp) {
+        console.log('  internal temp: ' + intTemp.toFixed(2) + ' C');
+        if (extTemp) {
+            console.log('  external temp: ' + extTemp.toFixed(2) + ' C');
+        } else {
+            console.log('  no external sensor');
+        }
+    });
+
 });


### PR DESCRIPTION
Changes: 
- [x] Updated function <code>toDegreeCelsius()</code> to contain the working logic to parse bytes to degrees Celsius. Returns NaN if both bytes are 255 (no external sensor). The device seems to return only multiples of 16 for the low byte, so 255 should never be returned for the low byte of a valid reading. Tested with TEMPer2, with and without external sensor connected.
- [x] Added external temp to <code>readTemperature()</code> callback. This doesn't seem to break existing code that only uses the first returned value.  Tested with TEMPer2, with and without external sensor connected.
- [x] Close the USB device after reading the value in <code>readTemperature()</code>.
- [x] Added function <code>toDegreeFahrenheit()</code>.
- [x] Updated USB device filtering to work with all devices where <code>vendorId==3141</code>.  Removed the product name filter, which is somewhat redundant and did not work with my TEMPer2_M12_V1.3 device.
- [x] Added function <code>toDegreeCelsius()</code> [correct spelling of 'Celsius'].  The previous function still exists, to support existing code. Recommend removing the misspelled function in a future version?
- [x] Added function <code>convertCelsiusToFahrenheit()</code>, which is used internally and can be used externally also.
- [x] Enhanced test.js to display internal and external temps for all attached devices.  I only have one device right now, so haven't actually tested with multiple devices yet.
- [x] Updated <code>node-hid</code> dependency to 0.5.1 (0.2.2 appears to depend on another package that is no longer available)