### PR TITLE
fix: upgrade node-hid for modern node compile support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,17 @@
   "author": "Andreas Müller <andreas@kwiqly.com> (http://asmuelle.de/)",
   "name": "temper1",
   "description": "Measure temperatures with temper1 usb thermometers.",
-   "contributors": [ 
+  "contributors": [
     {
       "name": "Sebastian Janzen"
     },
     {
       "name": "R.J. Steinert"
     },
-    { "name": "Eric McCarthy", "email":"eric@limulus.net"}
+    {
+      "name": "Eric McCarthy",
+      "email": "eric@limulus.net"
+    }
   ],
   "version": "0.0.9",
   "scripts": {
@@ -22,5 +25,7 @@
   "engines": {
     "node": "*"
   },
-  "dependencies": {"node-hid":"~0.5.1"}
+  "dependencies": {
+    "node-hid": "^0.7.7"
+  }
 }


### PR DESCRIPTION
Upgrading node-hid fixes support for node v10.

```
> node-hid@0.5.7 install /tmp/node-temper1/node_modules/node-hid
> prebuild-install || node-gyp rebuild

prebuild-install WARN install No prebuilt binaries found (target=10.13.0 runtime=node arch=arm platform=linux)
make: Entering directory '/tmp/node-temper1/node_modules/node-hid/build'
  CC(target) Release/obj.target/hidapi/hidapi/libusb/hid.o
../hidapi/libusb/hid.c: In function ‘hid_read_timeout’:
../hidapi/libusb/hid.c:1078:6: warning: variable ‘bytes_read’ might be clobbered by ‘longjmp’ or ‘vfork’ [-Wclobbered]
  int bytes_read = -1;
      ^~~~~~~~~~
  AR(target) Release/obj.target/hidapi.a
  COPY Release/hidapi.a
  CXX(target) Release/obj.target/HID/src/HID.o
../src/HID.cc: In member function ‘void HID::readResultsToJSCallbackArguments(HID::ReceiveIOCB*, v8::Local<v8::Value>*)’:
../src/HID.cc:207:74: error: no matching function for call to ‘v8::Function::NewInstance(int, v8::Local<v8::Value> [1])’
     Local<Object> buf = nodeBufConstructor->NewInstance(1, nodeBufferArgs);
                                                                          ^
In file included from /home/pi/.node-gyp/10.13.0/include/node/node.h:63:0,
                 from ../src/HID.cc:30:
/home/pi/.node-gyp/10.13.0/include/node/v8.h:3993:44: note: candidate: v8::MaybeLocal<v8::Object> v8::Function::NewInstance(v8::Local<v8::Context>, int, v8::Local<v8::Value>*) const
   V8_WARN_UNUSED_RESULT MaybeLocal<Object> NewInstance(
                                            ^~~~~~~~~~~
/home/pi/.node-gyp/10.13.0/include/node/v8.h:3993:44: note:   candidate expects 3 arguments, 2 provided
/home/pi/.node-gyp/10.13.0/include/node/v8.h:3996:44: note: candidate: v8::MaybeLocal<v8::Object> v8::Function::NewInstance(v8::Local<v8::Context>) const
   V8_WARN_UNUSED_RESULT MaybeLocal<Object> NewInstance(
                                            ^~~~~~~~~~~
/home/pi/.node-gyp/10.13.0/include/node/v8.h:3996:44: note:   candidate expects 1 argument, 2 provided
../src/HID.cc: In static member function ‘static void HID::recvAsyncDone(uv_work_t*)’:
../src/HID.cc:231:32: warning: ‘v8::Local<v8::Value> Nan::Callback::Call(int, v8::Local<v8::Value>*) const’ is deprecated [-Wdeprecated-declarations]
   iocb->_callback->Call(2, argv);
                                ^
In file included from ../src/HID.cc:31:0:
../../nan/nan.h:1674:3: note: declared here
   Call(int argc, v8::Local<v8::Value> argv[]) const {
   ^~~~
../src/HID.cc: In static member function ‘static Nan::NAN_METHOD_RETURN_TYPE HID::sendFeatureReport(Nan::NAN_METHOD_ARGS_TYPE)’:
../src/HID.cc:363:72: warning: ‘int32_t v8::Value::Int32Value() const’ is deprecated: Use maybe version [-Wdeprecated-declarations]
     message.push_back((unsigned char) messageArray->Get(i)->Int32Value());
                                                                        ^
In file included from /home/pi/.node-gyp/10.13.0/include/node/v8.h:26:0,
                 from /home/pi/.node-gyp/10.13.0/include/node/node.h:63,
                 from ../src/HID.cc:30:
/home/pi/.node-gyp/10.13.0/include/node/v8.h:2478:46: note: declared here
   V8_DEPRECATED("Use maybe version", int32_t Int32Value() const);
                                              ^
/home/pi/.node-gyp/10.13.0/include/node/v8config.h:324:3: note: in definition of macro ‘V8_DEPRECATED’
   declarator __attribute__((deprecated(message)))
   ^~~~~~~~~~
../src/HID.cc: In static member function ‘static Nan::NAN_METHOD_RETURN_TYPE HID::New(Nan::NAN_METHOD_ARGS_TYPE)’:
../src/HID.cc:404:46: warning: ‘int32_t v8::Value::Int32Value() const’ is deprecated: Use maybe version [-Wdeprecated-declarations]
       int32_t vendorId = info[0]->Int32Value();
                                              ^
In file included from /home/pi/.node-gyp/10.13.0/include/node/v8.h:26:0,
                 from /home/pi/.node-gyp/10.13.0/include/node/node.h:63,
                 from ../src/HID.cc:30:
/home/pi/.node-gyp/10.13.0/include/node/v8.h:2478:46: note: declared here
   V8_DEPRECATED("Use maybe version", int32_t Int32Value() const);
                                              ^
/home/pi/.node-gyp/10.13.0/include/node/v8config.h:324:3: note: in definition of macro ‘V8_DEPRECATED’
   declarator __attribute__((deprecated(message)))
   ^~~~~~~~~~
../src/HID.cc:405:47: warning: ‘int32_t v8::Value::Int32Value() const’ is deprecated: Use maybe version [-Wdeprecated-declarations]
       int32_t productId = info[1]->Int32Value();
                                               ^
In file included from /home/pi/.node-gyp/10.13.0/include/node/v8.h:26:0,
                 from /home/pi/.node-gyp/10.13.0/include/node/node.h:63,
                 from ../src/HID.cc:30:
/home/pi/.node-gyp/10.13.0/include/node/v8.h:2478:46: note: declared here
   V8_DEPRECATED("Use maybe version", int32_t Int32Value() const);
                                              ^
/home/pi/.node-gyp/10.13.0/include/node/v8config.h:324:3: note: in definition of macro ‘V8_DEPRECATED’
   declarator __attribute__((deprecated(message)))
   ^~~~~~~~~~
../src/HID.cc:409:62: warning: ‘v8::String::Value::Value(v8::Local<v8::Value>)’ is deprecated: Use Isolate version [-Wdeprecated-declarations]
         serialPointer = (wchar_t*) *v8::String::Value(info[2]);
                                                              ^
In file included from /home/pi/.node-gyp/10.13.0/include/node/v8.h:26:0,
                 from /home/pi/.node-gyp/10.13.0/include/node/node.h:63,
                 from ../src/HID.cc:30:
/home/pi/.node-gyp/10.13.0/include/node/v8.h:2916:51: note: declared here
     V8_DEPRECATED("Use Isolate version", explicit Value(Local<v8::Value> obj));
                                                   ^
/home/pi/.node-gyp/10.13.0/include/node/v8config.h:324:3: note: in definition of macro ‘V8_DEPRECATED’
   declarator __attribute__((deprecated(message)))
   ^~~~~~~~~~
../src/HID.cc: In static member function ‘static Nan::NAN_METHOD_RETURN_TYPE HID::setNonBlocking(Nan::NAN_METHOD_ARGS_TYPE)’:
../src/HID.cc:443:37: warning: ‘int32_t v8::Value::Int32Value() const’ is deprecated: Use maybe version [-Wdeprecated-declarations]
   blockStatus = info[0]->Int32Value();
                                     ^
In file included from /home/pi/.node-gyp/10.13.0/include/node/v8.h:26:0,
                 from /home/pi/.node-gyp/10.13.0/include/node/node.h:63,
                 from ../src/HID.cc:30:
/home/pi/.node-gyp/10.13.0/include/node/v8.h:2478:46: note: declared here
   V8_DEPRECATED("Use maybe version", int32_t Int32Value() const);
                                              ^
/home/pi/.node-gyp/10.13.0/include/node/v8config.h:324:3: note: in definition of macro ‘V8_DEPRECATED’
   declarator __attribute__((deprecated(message)))
   ^~~~~~~~~~
../src/HID.cc: In static member function ‘static Nan::NAN_METHOD_RETURN_TYPE HID::write(Nan::NAN_METHOD_ARGS_TYPE)’:
../src/HID.cc:471:74: warning: ‘int32_t v8::Value::Int32Value() const’ is deprecated: Use maybe version [-Wdeprecated-declarations]
       message.push_back((unsigned char) messageArray->Get(i)->Int32Value());
                                                                          ^
In file included from /home/pi/.node-gyp/10.13.0/include/node/v8.h:26:0,
                 from /home/pi/.node-gyp/10.13.0/include/node/node.h:63,
                 from ../src/HID.cc:30:
/home/pi/.node-gyp/10.13.0/include/node/v8.h:2478:46: note: declared here
   V8_DEPRECATED("Use maybe version", int32_t Int32Value() const);
                                              ^
/home/pi/.node-gyp/10.13.0/include/node/v8config.h:324:3: note: in definition of macro ‘V8_DEPRECATED’
   declarator __attribute__((deprecated(message)))
   ^~~~~~~~~~
../src/HID.cc: In static member function ‘static Nan::NAN_METHOD_RETURN_TYPE HID::devices(Nan::NAN_METHOD_ARGS_TYPE)’:
../src/HID.cc:535:38: warning: ‘int32_t v8::Value::Int32Value() const’ is deprecated: Use maybe version [-Wdeprecated-declarations]
       vendorId = info[0]->Int32Value();
                                      ^
In file included from /home/pi/.node-gyp/10.13.0/include/node/v8.h:26:0,
                 from /home/pi/.node-gyp/10.13.0/include/node/node.h:63,
                 from ../src/HID.cc:30:
/home/pi/.node-gyp/10.13.0/include/node/v8.h:2478:46: note: declared here
   V8_DEPRECATED("Use maybe version", int32_t Int32Value() const);
                                              ^
/home/pi/.node-gyp/10.13.0/include/node/v8config.h:324:3: note: in definition of macro ‘V8_DEPRECATED’
   declarator __attribute__((deprecated(message)))
   ^~~~~~~~~~
../src/HID.cc:536:39: warning: ‘int32_t v8::Value::Int32Value() const’ is deprecated: Use maybe version [-Wdeprecated-declarations]
       productId = info[1]->Int32Value();
                                       ^
In file included from /home/pi/.node-gyp/10.13.0/include/node/v8.h:26:0,
                 from /home/pi/.node-gyp/10.13.0/include/node/node.h:63,
                 from ../src/HID.cc:30:
/home/pi/.node-gyp/10.13.0/include/node/v8.h:2478:46: note: declared here
   V8_DEPRECATED("Use maybe version", int32_t Int32Value() const);
                                              ^
/home/pi/.node-gyp/10.13.0/include/node/v8config.h:324:3: note: in definition of macro ‘V8_DEPRECATED’
   declarator __attribute__((deprecated(message)))
   ^~~~~~~~~~
HID.target.mk:110: recipe for target 'Release/obj.target/HID/src/HID.o' failed
make: *** [Release/obj.target/HID/src/HID.o] Error 1
make: Leaving directory '/tmp/node-temper1/node_modules/node-hid/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/home/pi/.nvm/versions/node/v10.13.0/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:262:23)
gyp ERR! stack     at ChildProcess.emit (events.js:182:13)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:240:12)
gyp ERR! System Linux 4.14.79-v7+
gyp ERR! command "/home/pi/.nvm/versions/node/v10.13.0/bin/node" "/home/pi/.nvm/versions/node/v10.13.0/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /tmp/node-temper1/node_modules/node-hid
gyp ERR! node -v v10.13.0
gyp ERR! node-gyp -v v3.8.0
gyp ERR! not ok 
npm WARN temper1@0.0.9 No license field.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! node-hid@0.5.7 install: `prebuild-install || node-gyp rebuild`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the node-hid@0.5.7 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/pi/.npm/_logs/2019-02-20T23_06_46_116Z-debug.log
```